### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     strategy:
       matrix:


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.